### PR TITLE
feat: add rotate actions + O-piece rotate test (no-op)

### DIFF
--- a/src/main/java/com/example/tetoris/application/GameSessionService.java
+++ b/src/main/java/com/example/tetoris/application/GameSessionService.java
@@ -1,0 +1,115 @@
+package com.example.tetoris.application;
+
+import com.example.tetoris.domain.model.Board;
+import com.example.tetoris.domain.model.GameState;
+import com.example.tetoris.domain.model.Piece;
+import com.example.tetoris.domain.model.impl.GridBoard;
+import com.example.tetoris.domain.value.Position;
+import com.example.tetoris.domain.value.Size;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * メモリ内ゲームセッション管理（MVP）。
+ * - 単純なOブロックをスポーンし、基本操作のみ適用。
+ */
+public class GameSessionService {
+
+  public record Session(GameState state, int rev) {}
+
+  private final Map<String, Session> sessions = new ConcurrentHashMap<>();
+  private final Map<String, String> startKeyToId = new ConcurrentHashMap<>();
+  private final Map<String, Map<String, Session>> idempotencyBySession = new ConcurrentHashMap<>();
+
+  public static class NotFoundException extends RuntimeException {
+    public NotFoundException(String id) {
+      super("game not found: " + id);
+    }
+  }
+
+  public String startGame(Optional<Integer> widthOpt, Optional<Integer> heightOpt) {
+    int w = widthOpt.orElse(10);
+    int h = heightOpt.orElse(20);
+    Size size = Size.of(w, h);
+    Board board = GridBoard.empty(size);
+    Piece current = oBlockAt(w / 2, 0);
+    GameState state = GameState.of(board, current);
+    String id = UUID.randomUUID().toString();
+    sessions.put(id, new Session(state, 0));
+    return id;
+  }
+
+  /** Idempotent start: 同一キーなら同一IDを返す。 */
+  public String startGameIdempotent(
+      Optional<Integer> widthOpt, Optional<Integer> heightOpt, Optional<String> idempotencyKey) {
+    if (idempotencyKey.isPresent()) {
+      String key = idempotencyKey.get();
+      String existing = startKeyToId.get(key);
+      if (existing != null) {
+        return existing;
+      }
+      String id = startGame(widthOpt, heightOpt);
+      startKeyToId.put(key, id);
+      return id;
+    }
+    return startGame(widthOpt, heightOpt);
+  }
+
+  public Session get(String id) {
+    Session s = sessions.get(id);
+    if (s == null) throw new NotFoundException(id);
+    return s;
+  }
+
+  public Session apply(String id, String action, int repeat) {
+    Session s = get(id);
+    GameState st = s.state();
+    for (int i = 0; i < Math.max(1, repeat); i++) {
+      st = switch (action) {
+        case "MOVE_LEFT" -> st.moveLeft();
+        case "MOVE_RIGHT" -> st.moveRight();
+        case "SOFT_DROP" -> st.softDrop();
+        case "HARD_DROP" -> st.hardDrop();
+        case "ROTATE_CW" -> st.rotateCW();
+        case "ROTATE_CCW" -> st.rotateCCW();
+        default -> st; // 未対応は無変化
+      };
+    }
+    Session updated = new Session(st, s.rev() + 1);
+    sessions.put(id, updated);
+    return updated;
+  }
+
+  /** Idempotent apply: 同一キーなら同じ結果（rev/state）を返す。 */
+  public Session applyIdempotent(String id, String idempotencyKey, String action, int repeat) {
+    Map<String, Session> m = idempotencyBySession.computeIfAbsent(id, k -> new ConcurrentHashMap<>());
+    Session prev = m.get(idempotencyKey);
+    if (prev != null) return prev;
+    Session res = apply(id, action, repeat);
+    m.put(idempotencyKey, res);
+    return res;
+  }
+
+  public void delete(String id) {
+    sessions.remove(id);
+  }
+
+  private static Piece oBlockAt(int x, int y) {
+    // 2x2 O ミノの簡易実装（絶対座標）
+    return new Piece() {
+      @Override
+      public List<Position> cells() {
+        List<Position> list = new ArrayList<>();
+        list.add(new Position(x, y));
+        list.add(new Position(x + 1, y));
+        list.add(new Position(x, y + 1));
+        list.add(new Position(x + 1, y + 1));
+        return list;
+      }
+    };
+  }
+}

--- a/src/main/java/com/example/tetoris/domain/model/GameState.java
+++ b/src/main/java/com/example/tetoris/domain/model/GameState.java
@@ -1,0 +1,102 @@
+package com.example.tetoris.domain.model;
+
+import com.example.tetoris.domain.value.Position;
+import java.util.ArrayList;
+import java.util.List;
+
+/** MVP段階のGameState。必要最小の操作から実装を開始する。 */
+public final class GameState {
+  private final Board board;
+  private final Piece current;
+
+  private GameState(Board board, Piece current) {
+    this.board = board;
+    this.current = current;
+  }
+
+  public static GameState of(Board board, Piece current) {
+    return new GameState(board, current);
+  }
+
+  public Board board() {
+    return board;
+  }
+
+  public Piece current() {
+    return current;
+  }
+
+  public GameState moveLeft() {
+    Piece moved = new ShiftedPiece(current, -1, 0);
+    if (board.canPlace(moved)) {
+      return new GameState(board, moved);
+    }
+    return this;
+  }
+
+  public GameState moveRight() {
+    Piece moved = new ShiftedPiece(current, 1, 0);
+    if (board.canPlace(moved)) {
+      return new GameState(board, moved);
+    }
+    return this;
+  }
+
+  public GameState rotateCW() {
+    return this; // 後続ステップで実装
+  }
+
+  public GameState rotateCCW() {
+    return this; // 後続ステップで実装
+  }
+
+  public GameState softDrop() {
+    Piece moved = new ShiftedPiece(current, 0, 1);
+    if (board.canPlace(moved)) {
+      return new GameState(board, moved);
+    }
+    return this;
+  }
+
+  public GameState hardDrop() {
+    Piece falling = this.current;
+    while (true) {
+      Piece next = new ShiftedPiece(falling, 0, 1);
+      if (board.canPlace(next)) {
+        falling = next;
+      } else {
+        break;
+      }
+    }
+    return new GameState(board, falling);
+  }
+
+  public GameState holdSwap() {
+    return this; // 後続ステップで実装
+  }
+
+  public GameState tick() {
+    return this; // 後続ステップで実装
+  }
+
+  private static final class ShiftedPiece implements Piece {
+    private final Piece base;
+    private final int dx;
+    private final int dy;
+
+    private ShiftedPiece(Piece base, int dx, int dy) {
+      this.base = base;
+      this.dx = dx;
+      this.dy = dy;
+    }
+
+    @Override
+    public List<Position> cells() {
+      List<Position> out = new ArrayList<>();
+      for (Position p : base.cells()) {
+        out.add(new Position(p.x() + dx, p.y() + dy));
+      }
+      return out;
+    }
+  }
+}

--- a/src/test/java/com/example/tetoris/domain/model/GameStateRotateTest.java
+++ b/src/test/java/com/example/tetoris/domain/model/GameStateRotateTest.java
@@ -1,0 +1,49 @@
+package com.example.tetoris.domain.model;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.example.tetoris.domain.model.impl.GridBoard;
+import com.example.tetoris.domain.value.Position;
+import com.example.tetoris.domain.value.Size;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class GameStateRotateTest {
+
+  @Test
+  @DisplayName("Oピース: rotateCWしてもセルは変化しない（MVP段階）")
+  void rotateCW_keepsOShape() {
+    Size size = Size.of(10, 20);
+    Board board = GridBoard.empty(size);
+
+    Piece o = oBlockAt(5, 0);
+    GameState s = GameState.of(board, o);
+
+    GameState r = s.rotateCW();
+
+    assertEquals(asSet(o.cells()), asSet(r.current().cells()), "Oは回転しても同一形状");
+  }
+
+  private static Piece oBlockAt(int x, int y) {
+    return new Piece() {
+      @Override
+      public List<Position> cells() {
+        List<Position> c = new ArrayList<>();
+        c.add(new Position(x, y));
+        c.add(new Position(x + 1, y));
+        c.add(new Position(x, y + 1));
+        c.add(new Position(x + 1, y + 1));
+        return c;
+      }
+    };
+  }
+
+  private static Set<Position> asSet(List<Position> cells) {
+    return new HashSet<>(cells);
+  }
+}
+


### PR DESCRIPTION
Closes #ROTATE-1\n\n- app: handle ROTATE_CW/ROTATE_CCW\n- domain: stub rotateCCW (to be implemented with SRS)\n- test: GameStateRotateTest (O-piece no-op rotation)\n\nNotes: Full SRS rotation to follow in PR2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced in-memory game sessions for Tetoris: start, retrieve, update, and delete sessions.
  * Start a new game with default or custom board size.
  * Control pieces with move left/right, soft drop, hard drop, and rotate actions.
  * Consistent results supported for repeated start/apply requests.
* **Tests**
  * Added rotation behavior tests to ensure the O-block remains unchanged on rotation, validating current MVP behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->